### PR TITLE
Modify exif data in-place to prevent image re-compression

### DIFF
--- a/exif_date_from_filename.py
+++ b/exif_date_from_filename.py
@@ -201,7 +201,7 @@ def process_directory(
     :param force: Force update even if DateTimeOriginal tag is already set by external software
     :param config: Path to the config file
     """
-    # cursed logging setupa
+    # cursed logging setup
     handler = logging.StreamHandler()
     formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
     handler.setFormatter(formatter)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 piexif
-pillow
 fire
 tqdm
 pyyaml


### PR DESCRIPTION
Previously, the image would be saved and therefore compressed again. 

This change uses piexif's ability to modify the exif data without needing to re-save the image

Also should get rid of the Windows saving bug/workaround